### PR TITLE
ath79: add support for COMFAST CF-E385AC

### DIFF
--- a/target/linux/ath79/dts/qca9558_comfast_cf-e385ac.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-e385ac.dts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "comfast,cf-e385ac", "qca,qca9558";
+	model = "COMFAST CF-E385AC";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-running = &led_lan;
+		led-upgrade = &led_lan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_lan: lan {
+			label = "green:lan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wan {
+			label = "red:wan";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <500>;
+		always-running;
+	};
+};
+
+&pinmux {
+	pinctrl-names = "default";
+	pinctrl-0 = <&jtag_disable_pins>;
+};
+
+&wdt {
+	status = "disabled";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			art: partition@40000 {
+				label = "art";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xf90000>;
+			};
+
+			partition@fe0000 {
+				label = "configs";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "art-backup";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,mib-poll-interval = <500>;
+		qca,ar8327-initvals = <
+			0x04 0x87600000 /* PORT0 PAD MODE CTRL: RGMII, MAC0/6 exchage, tx_delay 01, rx_delay 10 */
+			0x0c 0x00080080 /* PORT6 PAD MODE CTRL: SGMII */
+			0x10 0x81000080 /* POWER_ON_STRIP */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_art_lan>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	nvmem-cells = <&macaddr_art_lan>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath10k: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+
+		nvmem-cells = <&macaddr_art_wlan>, <&precal_ath10k>;
+		nvmem-cell-names = "mac-address", "pre-calibration";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_wlan>, <&cal_ath9k>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <8>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_lan: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_art_wlan: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+
+	cal_ath9k: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	precal_ath10k: calibration@5000 {
+		reg = <0x5000 0x2f20>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -166,9 +166,11 @@ comfast,cf-e314n-v2)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
-comfast,cf-e375ac)
+comfast,cf-e375ac|\
+comfast,cf-e385ac)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x04"
 	ucidef_set_led_switch "wan" "WAN" "red:wan" "switch0" "0x02"
+	ucidef_set_led_wlan "wlan" "WLAN" "blue:wlan2g" "phy1tpt"
 	;;
 comfast,cf-e5)
 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x02"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -239,6 +239,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan"
 		;;
+	comfast,cf-e385ac)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan" "1:wan" "6u@eth1"
+		;;
 	comfast,cf-e560ac|\
 	qca,ap143-8m|\
 	qca,ap143-16m|\
@@ -599,7 +603,8 @@ ath79_setup_macs()
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
 		;;
-	comfast,cf-e375ac)
+	comfast,cf-e375ac|\
+	comfast,cf-e385ac)
 		wan_mac=$(macaddr_add $(mtd_get_mac_binary art 0x0) 1)
 		;;
 	compex,wpj344-16m|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -690,6 +690,16 @@ define Device/comfast_cf-e375ac
 endef
 TARGET_DEVICES += comfast_cf-e375ac
 
+define Device/comfast_cf-e385ac
+  SOC := qca9558
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E385AC
+  DEVICE_PACKAGES := kmod-ath10k-ct \
+	ath10k-firmware-qca9984-ct -uboot-envtools
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += comfast_cf-e385ac
+
 define Device/comfast_cf-e5
   SOC := qca9531
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
Forward-port from ar71xx target the board introduced in commit 650a5e9 ("ar71xx: add support for COMFAST CF-E385AC")

**Short specification:**
--------------------
- 720/600/200 MHz (CPU/DDR/AHB)
- 256 MB of RAM (DDR2)
- 16 MB of FLASH (SPI NOR)
- 2x 10/100/1000 Mbps Ethernet, with PoE support
- 3T3R 2.4 GHz (QCA9558)
- 4T4R 5 GHz (QCA9984)
- 7x internal antennas
- 1x RGB LED (driven by GPIO)
- 1x button (reset)
- UART, LEDs/GPIO and USB headers on PCB
- external watchdog (Pericon Technology PT7A7514)

**MAC addresses:**
--------------
Though the OEM firmware has three adresses in the usual locations, it appears that the assigned addresses are just incremented in a different way:
```text
interface  address  location
LAN:       *:90     0x0 (label)
WAN        *:91     0x1002
WLAN 2.4g  *:9A     n/a (0x0 + 10)
WLAN 5g    *:92     0x6
```
**Installation:**
------------
A standard openwrt image can be flashed directly from OEM stock firmware.
**Note:** the router will keep the previous configuration, including the stock password. After flashing, enter failsafe mode[^1] to reset it.

[^1]: https://openwrt.org/docs/guide-user/troubleshooting/failsafe_and_factory_reset